### PR TITLE
Re-added examples without unsupported rst options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,13 +22,48 @@ Features
 - Event building assistance with event validation on receive and publish.
 - Following a context link.
 
-
 Installation
 ============
 
 Install the project for by running:
 
     pip install eiffellib
+
+Examples
+========
+
+Subscribing to an event
+-----------------------
+
+.. code-block:: python
+
+    import time
+    from eiffellib.subscribers import RabbitMQSubscriber
+
+
+    def callback(event, context):
+        print(event.pretty)
+
+    SUBSCRIBER = RabbitMQSubscriber(host="127.0.0.1", queue="eiffel",
+                                    exchange="public")
+    SUBSCRIBER.subscribe("EiffelActivityTriggeredEvent", callback)
+    SUBSCRIBER.start()
+    while True:
+        time.sleep(0.1)
+
+Publishing an event
+-------------------
+
+.. code-block:: python
+
+    from eiffellib.publishers import RabbitMQPublisher
+    from eiffellib.events import EiffelActivityTriggeredEvent
+
+    PUBLISHER = RabbitMQPublisher(host="127.0.0.1")
+    PUBLISHER.start()
+    ACTIVITY_TRIGGERED = EiffelActivityTriggeredEvent()
+    ACTIVITY_TRIGGERED.data.add("name", "Test activity")
+    PUBLISHER.send_event(ACTIVITY_TRIGGERED)
 
 Contribute
 ==========


### PR DESCRIPTION
Change-Id: I01988b05942472f1d071c31beb1b50a1059513d6

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
https://github.com/eiffel-community/eiffel-pythonlib/issues/1

### Description of the Change
Added a separate heading for examples, without the unsupported code-block options (e.g :caption:)

### Benefits
Now there are (visible) code examples again.

### Possible Drawbacks
None that I can think of.

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <Fredrik Fristedt> <fredrik.fristedt@axis.com>
