### PR TITLE
Correct library name for the package when building wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers = Development Status :: 5 - Production/Stable
 
 [files]
 packages =
-    eiffel
+    eiffellib
 
 [extras]
 
@@ -24,7 +24,7 @@ addopts = tests
 
 [pytest]
 addopts =
-    --cov eiffel --cov-report term-missing
+    --cov eiffellib --cov-report term-missing
     --verbose
 
 [aliases]


### PR DESCRIPTION
### Applicable Issues
Fixes: #3 

### Description of the Change
Change the package name in the setup.cfg from "eiffel" to "eiffellib". Missed this when changing the package name.

### Alternate Designs
None. Changing the package name back to "eiffel" could work, but it's too generic.

### Benefits
Package can be installed from pypi.org

### Possible Drawbacks
none

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobiaspn@axis.com>
