### PR TITLE
Fix examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,16 @@ Install the project for by running:
 Examples
 ========
 
+Start RabbitMQ
+--------------
+
+In order for these examples to work you need a RabbitMQ server:
+
+.. code-block::
+
+   # From https://hub.docker.com/_/rabbitmq
+   docker run -d --hostname my-rabbit --name some-rabbit -p 8080:15672 -p 5672:5672 rabbitmq:3-management
+
 Subscribing to an event
 -----------------------
 
@@ -44,8 +54,8 @@ Subscribing to an event
     def callback(event, context):
         print(event.pretty)
 
-    SUBSCRIBER = RabbitMQSubscriber(host="127.0.0.1", queue="eiffel",
-                                    exchange="public")
+    SUBSCRIBER = RabbitMQSubscriber(host="127.0.0.1", port=5672, ssl=False,
+                                    queue="eiffel", exchange="amq.fanout")
     SUBSCRIBER.subscribe("EiffelActivityTriggeredEvent", callback)
     SUBSCRIBER.start()
     while True:
@@ -59,7 +69,8 @@ Publishing an event
     from eiffellib.publishers import RabbitMQPublisher
     from eiffellib.events import EiffelActivityTriggeredEvent
 
-    PUBLISHER = RabbitMQPublisher(host="127.0.0.1")
+    PUBLISHER = RabbitMQPublisher(host="127.0.0.1", exchange="amq.fanout", ssl=False,
+                                  port=5672)
     PUBLISHER.start()
     ACTIVITY_TRIGGERED = EiffelActivityTriggeredEvent()
     ACTIVITY_TRIGGERED.data.add("name", "Test activity")


### PR DESCRIPTION
Examples were a bit too generic and hard to understand.
Added a How-To on a RabbitMQ docker
Updated all examples to use the RabbitMQ docker
Tested all examples on a clean machine. They should now work.

### Applicable Issues
Fixes: #6 

### Description of the Change
Added RabbitMQ docker to examples. Updated examples to use docker.

### Alternate Designs
Could skip it all together in order to force people to set it up themselves.

### Benefits
Easier to use the library and get an understanding

### Possible Drawbacks
"Forcing" people to use RabbitMQ and docker.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobiaspn@axis.com>
