### PR TITLE
If Context is None, call a subscriber with None on Context.

### DIFF
--- a/eiffellib/activity.py
+++ b/eiffellib/activity.py
@@ -66,7 +66,8 @@ class Activity():
             self.triggered.data.add("triggers", self.triggers)
         if self.execution_type is not None:
             self.triggered.data.add("executionType", self.execution_type)
-        self.triggered.links.add("CONTEXT", context)
+        if context is not None:
+            self.triggered.links.add("CONTEXT", context)
         self.triggered.meta.add("source", self.source)
         self.publisher.send_event(self.triggered)
 
@@ -81,7 +82,8 @@ class Activity():
             return
 
         self.started = EiffelActivityStartedEvent()
-        self.started.links.add("CONTEXT", context)
+        if context is not None:
+            self.started.links.add("CONTEXT", context)
         self.started.links.add("ACTIVITY_EXECUTION", self.triggered)
         self.started.meta.add("source", self.source)
         self.publisher.send_event(self.started)
@@ -98,7 +100,8 @@ class Activity():
 
         self.finished = EiffelActivityFinishedEvent()
         self.finished.data.add("outcome", {"conclusion": "SUCCESSFUL"})
-        self.finished.links.add("CONTEXT", context)
+        if context is not None:
+            self.finished.links.add("CONTEXT", context)
         self.finished.links.add("ACTIVITY_EXECUTION", self.triggered)
         self.finished.meta.add("source", self.source)
         self.publisher.send_event(self.finished)
@@ -114,7 +117,8 @@ class Activity():
         self.canceled = EiffelActivityCanceledEvent()
         if reason is not None:
             self.canceled.data.add("reason", reason)
-        self.canceled.links.add("CONTEXT", context)
+        if context is not None:
+            self.canceled.links.add("CONTEXT", context)
         self.canceled.links.add("ACTIVITY_EXECUTION", self.triggered)
         self.canceled.meta.add("source", self.source)
         self.publisher.send_event(self.canceled)
@@ -127,10 +131,11 @@ class Activity():
         """
         try:
             self.activity_triggered(context)
-            self.pre_call(event, context)
+            call_context = context if context else self.triggered.meta.event_id
+            self.pre_call(event, call_context)
             self.activity_started(context)
-            self.call(event, context)
-            self.post_call(event, context)
+            self.call(event, call_context)
+            self.post_call(event, call_context)
             self.activity_finished(context)
         except Exception as exception:
             self.activity_canceled(context, str(exception))

--- a/eiffellib/subscribers/eiffel_subscriber.py
+++ b/eiffellib/subscribers/eiffel_subscriber.py
@@ -127,7 +127,7 @@ class EiffelSubscriber():
                 context = link.get("target")
                 break
         else:
-            context = event.meta.event_id
+            context = None
         return context
 
     def _call_followers(self, event):


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: #12 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
This fixes a problem where the eiffel subscriber would call
callbacks with a context link to illegal events.
Also handle None context in the Activity class

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We could remove the context callback variable instead. But not sure how many tools use that feature.

### Benefits
<!-- What benefits will be realized by the change? -->
No illegal events used as context in activity.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
none

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobiaspn@axis.com>
