### PR TITLE
Reconnect the connection thread if broker shuts down

### DIFF
--- a/eiffellib/lib/__init__.py
+++ b/eiffellib/lib/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/eiffellib/lib/base_rabbitmq.py
+++ b/eiffellib/lib/base_rabbitmq.py
@@ -1,0 +1,252 @@
+# Copyright 2020 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""RabbitMQ base connection."""
+import time
+import logging
+import threading
+import ssl as _ssl
+import pika
+
+
+_LOG = logging.getLogger(__name__)
+
+
+# pylint:disable=too-many-instance-attributes
+class BaseRabbitMQ:
+    """Base RabbitMQ connection object."""
+
+    _connection = None
+    _channel = None
+    _was_active = False
+    _closing = False
+
+    should_reconnect = False
+    active = False
+    connection_thread = None
+    running = False
+
+    # pylint:disable=too-many-arguments
+    def __init__(self, host, port, username, password, vhost, ssl):
+        """Set connection parameters."""
+        parameters = {"port": port}
+        if ssl is True:
+            context = _ssl.create_default_context()
+            ssl_options = pika.SSLOptions(context, host)
+            parameters["ssl_options"] = ssl_options
+        if username and password:
+            parameters["credentials"] = pika.PlainCredentials(username, password)
+        if vhost:
+            parameters["virtual_host"] = vhost
+
+        self.parameters = pika.ConnectionParameters(host, **parameters)
+
+    def reset_parameters(self):
+        """Reset parameters to default."""
+        self.should_reconnect = False
+        self.active = False
+        self._closing = False
+        self._was_active = False
+
+    def _setup(self, channel):
+        """Setup channel. Called after channel is opened.
+
+        :param channel: RabbitMQ channel.
+        :type channel: :obj:`pika.channel.Channel`
+        """
+        raise NotImplementedError
+
+    def _start(self, *args, **kwargs):
+        """Start up the RabbitMQ connection. Call when connection is ready."""
+        raise NotImplementedError
+
+    def _cancel(self):
+        """Cancel the RabbitMQ connection."""
+        raise NotImplementedError
+
+    def _on_start(self):
+        """Called just before starting the connection."""
+
+    def _on_connect(self):
+        """Called just before connecting."""
+
+    def reconnect(self):
+        """Reconnect RabbitMQ connection."""
+        self.should_reconnect = True
+        self.stop()
+
+    def connect(self):
+        """Connect to RabbitMQ."""
+        self._connection = pika.SelectConnection(self.parameters,
+                                                 on_open_callback=self._connection_open,
+                                                 on_close_callback=self._connection_close,
+                                                 on_open_error_callback=self._connection_open_error)
+
+    def close_connection(self):
+        """Close the RabbitMQ connection."""
+        self.active = False
+        if self._connection.is_closing or self._connection.is_closed:
+            _LOG.info("Connection is closing or already closed.")
+        else:
+            _LOG.info("Closing connection")
+            self._connection.close()
+
+    def _connection_open(self, connection):
+        """Connection opened callback. Create a RabbitMQ channel.
+
+        :param connection: Connection that was just opened.
+        :type connection: :obj:`pika.connection.Connection`
+        """
+        _LOG.info("Connection opened")
+        _LOG.info("Creating a new channel.")
+        connection.channel(on_open_callback=self._channel_open)
+
+    def _connection_close(self, _, reason):
+        """Connection closed callback.
+
+        Close the connection if told to, otherwise attempt reconnect.
+
+        :param connection: Connection that was closed.
+        :type connection: :obj:`pika.connection.Connection`
+        :param reason: Reason the connection was closed.
+        :type reason: str
+        """
+        self._channel = None
+        if self._closing:
+            self._connection.ioloop.stop()
+        else:
+            _LOG.warning("Connection closed, reconnecting: %s", reason)
+            self.reconnect()
+
+    def _connection_open_error(self, _, error):
+        """Connection error when starting callback. Reconnect.
+
+        :param connection: Connection that was closed.
+        :type connection: :obj:`pika.Connection`
+        :param error: Reason the connection was closed.
+        :type error: str
+        """
+        _LOG.error("Failed to open connection: %s", error)
+        self.reconnect()
+
+    def _channel_open(self, channel):
+        """Channel opened callback. Set close callback and call setup channel.
+
+        :param channel: Channel that was just opened.
+        :type channel: :obj:`pika.channel.Channel`
+        """
+        _LOG.info("Channel opened")
+        self._channel = channel
+        self._channel.add_on_close_callback(self._channel_closed)
+        self._setup(channel)
+
+    def _channel_closed(self, channel, reason):
+        """Channel closed callback. Close connection."""
+        _LOG.warning("Channel %i was closed: %s", channel, reason)
+        self.close_connection()
+
+    def close_channel(self):
+        """Close the RabbitMQ channel."""
+        _LOG.info("Closing the channel.")
+        self._channel.close()
+
+    def run(self):
+        """Reset parameters, connect to RabbitMQ and start the ioloop.
+
+        This is a blocking method.
+        """
+        self._on_connect()
+        self.reset_parameters()
+        self.connect()
+        self._connection.ioloop.start()
+
+    def keep_alive(self):
+        """Reconnect forever if the should_reconnect flag is set.
+
+        This is a blocking method.
+        """
+        reconnect_delay = 0
+        while True:
+            try:
+                self.run()
+            except KeyboardInterrupt:
+                self.stop()
+                break
+            if self.should_reconnect:
+                self.stop()
+                if self._was_active:
+                    reconnect_delay = 0
+                else:
+                    reconnect_delay += 1
+                if reconnect_delay > 30:
+                    reconnect_delay = 30
+                _LOG.info("Reconnecting after %d seconds", reconnect_delay)
+                time.sleep(reconnect_delay)
+            else:
+                break
+        self.running = False
+
+    def is_alive(self):
+        """Check if connection is alive or not.
+
+        Note that this only checks the 'running' flag and does not
+        deep-dive into the RabbitMQ connection and channel.
+
+        :return: Whether this connection is running or not.
+        :rtype: bool
+        """
+        return self.running
+
+    def wait_start(self):
+        """Block until connection starts."""
+        while not self.is_alive():
+            time.sleep(0.1)
+
+    def wait_close(self):
+        """Block until publisher closes."""
+        while self.is_alive():
+            time.sleep(0.1)
+
+    def start(self, wait=True):
+        """Start the RabbitMQ connection in a thread.
+
+        :param wait: Block until the connection starts. Defaults to True.
+        :type wait: bool
+        """
+        self._on_start()
+        self.connection_thread = threading.Thread(target=self.keep_alive)
+        self.connection_thread.daemon = True
+        self.connection_thread.start()
+        if wait:
+            self.wait_start()
+
+    def stop(self):
+        """Stop the RabbitMQ connection."""
+        if not self._closing:
+            self._closing = True
+            _LOG.info("Stopping")
+            if self.active:
+                self._cancel()
+                try:
+                    # Start the ioloop again in order for the callbacks
+                    # to fire, so that we can do a clean shutdown.
+                    self._connection.ioloop.start()
+                except RuntimeError:
+                    pass
+            else:
+                self._connection.ioloop.stop()
+            _LOG.info("Stopped")
+
+    close = stop  # Backwards compatibility

--- a/eiffellib/lib/base_rabbitmq.py
+++ b/eiffellib/lib/base_rabbitmq.py
@@ -127,7 +127,7 @@ class BaseRabbitMQ:
         if self._closing:
             self._connection.ioloop.stop()
         else:
-            _LOG.warning("Connection closed, reconnecting: %s", reason)
+            _LOG.warning("Connection closed, reconnecting: %r", reason)
             self.reconnect()
 
     def _connection_open_error(self, _, error):
@@ -138,7 +138,7 @@ class BaseRabbitMQ:
         :param error: Reason the connection was closed.
         :type error: str
         """
-        _LOG.error("Failed to open connection: %s", error)
+        _LOG.error("Failed to open connection: %r", error)
         self.reconnect()
 
     def _channel_open(self, channel):
@@ -154,7 +154,7 @@ class BaseRabbitMQ:
 
     def _channel_closed(self, channel, reason):
         """Channel closed callback. Close connection."""
-        _LOG.warning("Channel %i was closed: %s", channel, reason)
+        _LOG.warning("Channel %i was closed: %r", channel, reason)
         self.close_connection()
 
     def close_channel(self):

--- a/eiffellib/publishers/eiffel_publisher.py
+++ b/eiffellib/publishers/eiffel_publisher.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2020 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -27,9 +27,12 @@ class EiffelPublisher():
         """Start the pika rabbitmq connection."""
         raise NotImplementedError
 
-    def send_event(self, event):
+    def send_event(self, event, block=True):
         """Validate and send an eiffel event to server.
 
+        :param block: Set to True in order to block until ready.
+                      Default: True
+        :type block: bool
         :param event: Event to send.
         :type event: :obj:`eiffellib.events.eiffel_base_event.EiffelBaseEvent`
         """

--- a/eiffellib/publishers/rabbitmq_publisher.py
+++ b/eiffellib/publishers/rabbitmq_publisher.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2020 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -14,98 +14,161 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """RabbitMQ Eiffel publisher."""
-import queue
 import time
-import threading
-import ssl as _ssl
+import logging
 import pika
-from eiffellib.publishers import EiffelPublisher
+from eiffellib.publishers.eiffel_publisher import EiffelPublisher
+from eiffellib.lib.base_rabbitmq import BaseRabbitMQ
+
+_LOG = logging.getLogger(__name__)
 
 
-class RabbitMQPublisher(EiffelPublisher):  # pylint: disable=too-many-instance-attributes
+class RabbitMQPublisher(EiffelPublisher, BaseRabbitMQ):
     """Rabbitmq connection for sending messages."""
-
-    connection = None
-    connection_thread = None
-    channel = None
-    lock = None
-    running = False
+    _acks = 0
+    _nacks = 0
+    _delivered = 0
+    _last_delivered_tag = 0
 
     # pylint:disable=too-many-arguments
     def __init__(self, host, exchange, routing_key="eiffel",
                  username=None, password=None, port=5671, vhost=None,
                  source=None, ssl=True):
         """Initialize with host and create pika connection parameters."""
+        BaseRabbitMQ.__init__(self, host, port, username, password, vhost, ssl)
+        self._deliveries = {}
+        self._nacked_deliveries = []
         self.exchange = exchange
         self.routing_key = routing_key
-        self.message_queue = queue.Queue()
         self.source = source
 
-        # These two lines are similar between subscriber and publisher.
-        # But since we don't want a connection between them; this is fine.
-        parameters = {"port": port}
-        if ssl is True:
-            context = _ssl.create_default_context()
-            ssl_options = pika.SSLOptions(context, host)
-            parameters["ssl_options"] = ssl_options
-        if username and password:
-            parameters["credentials"] = pika.PlainCredentials(username, password)
-        if vhost:
-            parameters["virtual_host"] = vhost
+    # Tell EiffelPublisher to use BaseRabbitMQ.start
+    start = BaseRabbitMQ.start
 
-        self.parameters = pika.ConnectionParameters(host, **parameters)
+    def reset_parameters(self):
+        """Reset parameters to default."""
+        super().reset_parameters()
+        self._last_delivered_tag = 0
+        self._delivered = 0
 
-    def __del__(self):
-        """Close down connection."""
-        self.close()
+    def _setup(self, channel):
+        """Start the RabbitMQ publisher.
 
-    def start(self):
-        """Start the pika rabbitmq connection."""
-        self.connection = pika.BlockingConnection(self.parameters)
-        self.channel = self.connection.channel()
+        :param channel: RabbitMQ channel.
+        :type channel: :obj:`pika.channel.Channel`
+        """
+        self._channel.confirm_delivery(self._confirm_delivery)
+        self._start()
+
+    def _start(self, *args, **kwargs):
+        """Start the RabbitMQ publisher."""
+        _LOG.info("Start publishing messages.")
+        self._channel.add_on_cancel_callback(self._publisher_canceled)
+
+        # If the server shut down due to broker failure, attempt to recover lost messages.
+        self._nacked_deliveries.extend(self._deliveries.values())
+        self._deliveries.clear()
+        self._connection.ioloop.call_later(1, self._resend_nacked_deliveries)
+
+        self._was_active = True
+        self.active = True
         self.running = True
 
-        self.lock = threading.Lock()
-        thread = threading.Thread(target=self.keep_alive)
-        thread.daemon = True
-        thread.start()
+    def _cancel(self):
+        """Close channel and set active to False."""
+        if self._channel:
+            self.active = False
+            self.close_channel()
 
-    def send_event(self, event):
+    def _publisher_canceled(self, method_frame):
+        """Publisher remotely canceled callback.
+
+        :param method_frame: Frame which triggered this callback.
+        :type method_frame: class
+        """
+        _LOG.info("Publisher was canceled remotely, shutting down: %r", method_frame)
+        if self._channel:
+            self._channel.close()
+
+    def _resend_nacked_deliveries(self):
+        """Resend all NACKed deliveries. This method loops forever."""
+        deliveries = self._nacked_deliveries.copy()
+        if deliveries:
+            _LOG.info("Resending %i NACKed deliveries", len(deliveries))
+        self._nacked_deliveries.clear()
+        for event in deliveries:
+            self.send_event(event)
+        self._connection.ioloop.call_later(1, self._resend_nacked_deliveries)
+
+    def _confirm_delivery(self, method_frame):
+        """Confirm the delivery of events and make sure we resend NACKed events.
+
+        Note: This only checks for NACKs from the broker, not from any consumer.
+
+        :param method_frame: Frame which triggered this callback.
+        :type method_frame: class
+        """
+        method = method_frame.method
+        confirmation_type = method.NAME.split('.')[1].lower()
+        delivery_tag = method.delivery_tag
+        multiple = method.multiple
+
+        if multiple and delivery_tag == 0:
+            number_of_acks = len(self._deliveries)
+        else:
+            number_of_acks = delivery_tag - self._last_delivered_tag
+
+        if confirmation_type == 'ack':
+            self._acks += number_of_acks
+        elif confirmation_type == 'nack':
+            self._nacks += number_of_acks
+
+        if delivery_tag == 0:
+            if confirmation_type == "nack":
+                self._nacked_deliveries.extend(self._deliveries.values())
+            self._deliveries.clear()
+        else:
+            for tag in range(self._last_delivered_tag + 1, delivery_tag + 1):
+                if confirmation_type == "nack":
+                    self._nacked_deliveries.append(self._deliveries[tag])
+                self._deliveries.pop(tag)
+        self._last_delivered_tag = delivery_tag
+
+        _LOG.debug('Published %i messages, %i have yet to be confirmed, '
+                   '%i were acked and %i were nacked', self._acks+self._nacks,
+                   len(self._deliveries), self._acks, self._nacks)
+
+    def send_event(self, event, block=True):
         """Validate and send an eiffel event to the rabbitmq server.
 
         :param event: Event to send.
         :type event: :obj:`eiffellib.events.eiffel_base_event.EiffelBaseEvent`
+        :param block: Set to True in order to block for channel to become ready.
+                      Default: True
+        :type block: bool
         """
+        if block:
+            self.wait_start()
+            while self._channel is None or not self._channel.is_open:
+                time.sleep(0.1)
+
+        correlation_id = event.meta.event_id
+        properties = pika.BasicProperties(content_type="application/json",
+                                          delivery_mode=2)
         if self.source is not None:
             event.meta.add("source", self.source)
         event.validate()
-        self.send(event.serialized)
+        try:
+            self._channel.basic_publish(
+                self.exchange,
+                self.routing_key,
+                event.serialized,
+                properties,
+            )
+        except:
+            self._nacked_deliveries.append(event)
+            return
+        self._delivered += 1
+        self._deliveries[self._delivered] = event
 
-    def keep_alive(self):
-        """Keep the connection alive by taking the lock every 10s and do connection sleep."""
-        while self.running:
-            with self.lock:
-                self.connection.sleep(0.1)
-            time.sleep(10)
-
-    def close(self):
-        """Close the rabbitmq connection."""
-        if self.running:
-            self.running = False
-            with self.lock:
-                if self.connection is not None:
-                    self.connection.close()
-            self.connection = None
-            self.channel = None
-
-    def send(self, msg):
-        """Send a message to the rabbitmq server.
-
-        :param msg: Message to send.
-        :type msg: str
-        """
-        if self.channel is not None:
-            with self.lock:
-                self.channel.basic_publish(exchange=self.exchange,
-                                           routing_key=self.routing_key,
-                                           body=msg)
+    send = send_event


### PR DESCRIPTION
Make the subscriber and publisher interfaces more clear and stable.
Reconnect if the rabbitmq broker shuts down.
Configurable parameters for how many threads the subscriber is
allowed to create.
Keep track of published messages in order to requeue them if broker
goes down.
Create a base RabbitMQ class for shared methods.

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
fixes: #15 
fixes: #16 

### Description of the Change
Reconnect the subscribers and publishers if RabbitMQ should go down for some reason.

### Alternate Designs
Redesigned the code to utilize the SelectConnection instead of BlockingConnection of pika.
SelectConnection means async calls instead of sync calls of the BlockingConnection.
The BlockingConnection makes more understandable code whereas the SelectConnection is more reliable (We don't have to force thread-safety into a non-thread-safe tool).

### Benefits
Reconnection is always good. More reliable code.

### Possible Drawbacks
Could make it harder to maintain if one has problems with the SelectConnection.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobiaspn@axis.com>
