### PR TITLE
Specify open dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,10 @@ classifiers = Development Status :: 5 - Production/Stable
 
 [options]
 install_requires =
-    jsonschema == 3.0.0a2
+    jsonschema >= 3.0.0,<4
 
 [options.extras_require]
-rabbitmq = pika == 1.0.1
+rabbitmq = pika >= 1.0.1,<2
 
 [files]
 packages =


### PR DESCRIPTION
Declaring fixed version numbers for requirements makes it hard to
impossible to use eiffellib in certain circumstances. Libraries should
always declare as open dependencies as possible to allow some
flexibility for the clients.

Should a client not want to allow for this flexibility they can always
use a constraints.txt (pip) or poetry.lock (poetry) to lock down the
version numbers for any transient dependencies. The other way around is
impossible, i.e allow a less restrictive version requirement and the
declared requirement from the package.

Increasing the jsonschema from an alpha version to the actual release
resolves #34. Requiring an alpha release when the actual release was
finalized over two years ago is sort of wicked.

### Applicable Issues
 #34

### Description of the Change
Allow for versions of our dependencies to be higher than the given requirement as long as they are of the same major version.

### Alternate Designs
N/A

### Benefits
Users of eiffellib can use python > 3.7
Reduce the risk of an impossible version situation for our users.

### Possible Drawbacks
Our users might get dependencies from projects that does not adhere to semver (i.e broken non major versions).
This is commonly mitigated with a constraints.txt when using pip or a poetry.lock when using poetry.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Martin Wallgren martin@wallgren.it
