### PR TITLE
Add sepia routing keys to eiffellib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ __pycache__/*
 .pydevproject
 .settings
 .idea
+.vscode
+.python-version
 
 # Package files
 *.egg

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,4 +16,3 @@ formats: all
 python:
   install:
     - requirements: docs/requirements.txt
-    - requirements: requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -76,11 +76,44 @@ Publishing an event
     from eiffellib.events import EiffelActivityTriggeredEvent
 
     PUBLISHER = RabbitMQPublisher(host="127.0.0.1", exchange="amq.fanout", ssl=False,
-                                  port=5672)
+                                  port=5672, routing_key=None)
     PUBLISHER.start()
     ACTIVITY_TRIGGERED = EiffelActivityTriggeredEvent()
     ACTIVITY_TRIGGERED.data.add("name", "Test activity")
     PUBLISHER.send_event(ACTIVITY_TRIGGERED)
+
+Deprecation of routing key
+--------------------------
+
+The "routing_key" argument in the RabbitMQPublisher class has been deprecated.
+
+This deprecation also affects the default value of the "routing_key" argument and you will be getting warnings while running.
+
+
+The reason for this change is due to a misunderstanding of how routing keys are supposed to be used when eiffellib was first created.
+
+Each event will now be able to generate their own routing key every time the event is sent.
+
+This routing key is by default "eiffel._.$event_type._._" where the different values are "eiffel.$family.$event_type.$tag.$domainid".
+
+Please refer to https://eiffel-community.github.io/eiffel-sepia/rabbitmq-message-broker.html for more information about routing keys.
+
+
+To change to the new routing key behavior (and thus removing the warning), please set "routing_key" to "None" when initializing a new RabbitMQPublisher.
+
+.. code-block:: python
+
+    PUBLISHER = RabbitMQPublisher(host="127.0.0.1", exchange="amq.fanout", ssl=False,
+                                  port=5672, routing_key=None)
+
+In order to change "$family", "$tag" or "$domainid" in the routing key, they have to be set on the events.
+
+.. code-block:: python
+
+    PUBLISHER = RabbitMQPublisher(host="127.0.0.1", exchange="amq.fanout", ssl=False,
+                                  port=5672, routing_key=None)
+    EVENT = EiffelActivityTriggeredEvent(family="myfamily", tag="mytag", domain_id="mydomain")
+    PUBLISHER.send_event(EVENT)
 
 Contribute
 ==========

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,7 +7,7 @@ Start RabbitMQ
 
 In order for these examples to work you need a RabbitMQ server:
 
-.. code-block::
+.. code-block:: bash
 
    # From https://hub.docker.com/_/rabbitmq
    docker run -d --hostname my-rabbit --name some-rabbit -p 8080:15672 -p 5672:5672 rabbitmq:3-management
@@ -50,7 +50,8 @@ This code snippet will subscribe to an ActivityStarted in order to publish an Ac
 
     SUBSCRIBER = RabbitMQSubscriber(host="127.0.0.1", queue="pubsub", exchange="amq.fanout",
                                     ssl=False, port=5672)
-    PUBLISHER = RabbitMQPublisher(host="127.0.0.1", exchange="amq.fanout", port=5672, ssl=False)
+    PUBLISHER = RabbitMQPublisher(host="127.0.0.1", exchange="amq.fanout", port=5672, ssl=False,
+                                  routing_key=None)
 
     SUBSCRIBER.subscribe("EiffelActivityStartedEvent", callback)
     SUBSCRIBER.start()
@@ -98,7 +99,8 @@ An activity is just a callable which will send ActivityTriggered, Started and Fi
 
     SUBSCRIBER = RabbitMQSubscriber(host="127.0.0.1", queue="activity", exchange="amq.fanout",
                                     ssl=False, port=5672)
-    PUBLISHER = RabbitMQPublisher(host="127.0.0.1", exchange="amq.fanout", port=5672, ssl=False)
+    PUBLISHER = RabbitMQPublisher(host="127.0.0.1", exchange="amq.fanout", port=5672, ssl=False,
+                                  routing_key=None)
 
     SOURCE = {"host": os.getenv("HOSTNAME", "hostname"), "name": "MyActivity"}
     MY_ACTIVITY = MyActivity("Name of activity", PUBLISHER, SOURCE)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -102,7 +102,8 @@ An activity is just a callable which will send ActivityTriggered, Started and Fi
     PUBLISHER = RabbitMQPublisher(host="127.0.0.1", exchange="amq.fanout", port=5672, ssl=False,
                                   routing_key=None)
 
-    SOURCE = {"host": os.getenv("HOSTNAME", "hostname"), "name": "MyActivity"}
+    SOURCE = {"host": os.getenv("HOSTNAME", "hostname"), "name": "MyActivity",
+              "domainId": "example"}
     MY_ACTIVITY = MyActivity("Name of activity", PUBLISHER, SOURCE)
     SUBSCRIBER.subscribe("EiffelAnnouncementPublishedEvent", MY_ACTIVITY)
     SUBSCRIBER.start()

--- a/eiffellib/events/eiffel_activity_canceled_event.py
+++ b/eiffellib/events/eiffel_activity_canceled_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelActivityCanceledEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelActivityCanceledEvent, self).__init__(version)
+        super(EiffelActivityCanceledEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelActivityCanceledEvent", self.version)
         self.links = EiffelActivityCanceledLink()
         self.data = EiffelActivityCanceledData()

--- a/eiffellib/events/eiffel_activity_finished_event.py
+++ b/eiffellib/events/eiffel_activity_finished_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelActivityFinishedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelActivityFinishedEvent, self).__init__(version)
+        super(EiffelActivityFinishedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelActivityFinishedEvent", self.version)
         self.links = EiffelActivityFinishedLink()
         self.data = EiffelActivityFinishedData()

--- a/eiffellib/events/eiffel_activity_started_event.py
+++ b/eiffellib/events/eiffel_activity_started_event.py
@@ -34,9 +34,9 @@ class EiffelActivityStartedEvent(EiffelBaseEvent):
 
     version = "4.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelActivityStartedEvent, self).__init__(version)
+        super(EiffelActivityStartedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelActivityStartedEvent", self.version)
         self.links = EiffelActivityStartedLink()
         self.data = EiffelActivityStartedData()

--- a/eiffellib/events/eiffel_activity_triggered_event.py
+++ b/eiffellib/events/eiffel_activity_triggered_event.py
@@ -34,9 +34,9 @@ class EiffelActivityTriggeredEvent(EiffelBaseEvent):
 
     version = "4.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelActivityTriggeredEvent, self).__init__(version)
+        super(EiffelActivityTriggeredEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelActivityTriggeredEvent", self.version)
         self.links = EiffelActivityTriggeredLink()
         self.data = EiffelActivityTriggeredData()

--- a/eiffellib/events/eiffel_announcement_published_event.py
+++ b/eiffellib/events/eiffel_announcement_published_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelAnnouncementPublishedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelAnnouncementPublishedEvent, self).__init__(version)
+        super(EiffelAnnouncementPublishedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelAnnouncementPublishedEvent", self.version)
         self.links = EiffelAnnouncementPublishedLink()
         self.data = EiffelAnnouncementPublishedData()

--- a/eiffellib/events/eiffel_artifact_created_event.py
+++ b/eiffellib/events/eiffel_artifact_created_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelArtifactCreatedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelArtifactCreatedEvent, self).__init__(version)
+        super(EiffelArtifactCreatedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelArtifactCreatedEvent", self.version)
         self.links = EiffelArtifactCreatedLink()
         self.data = EiffelArtifactCreatedData()

--- a/eiffellib/events/eiffel_artifact_published_event.py
+++ b/eiffellib/events/eiffel_artifact_published_event.py
@@ -34,9 +34,9 @@ class EiffelArtifactPublishedEvent(EiffelBaseEvent):
 
     version = "3.1.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelArtifactPublishedEvent, self).__init__(version)
+        super(EiffelArtifactPublishedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelArtifactPublishedEvent", self.version)
         self.links = EiffelArtifactPublishedLink()
         self.data = EiffelArtifactPublishedData()

--- a/eiffellib/events/eiffel_artifact_reused_event.py
+++ b/eiffellib/events/eiffel_artifact_reused_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelArtifactReusedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelArtifactReusedEvent, self).__init__(version)
+        super(EiffelArtifactReusedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelArtifactReusedEvent", self.version)
         self.links = EiffelArtifactReusedLink()
         self.data = EiffelArtifactReusedData()

--- a/eiffellib/events/eiffel_base_event.py
+++ b/eiffellib/events/eiffel_base_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -169,14 +169,31 @@ class EiffelBaseEvent(object):
 
     schema_file = None
     __schema = None
+    __routing_key = "eiffel.{family}.{type}.{tag}.{domain_id}"
+    family = None
+    tag = None
+    domain_id = None
     version = "0.0.1"
     meta = EiffelBaseMeta("EiffelBaseEvent", version)
     links = EiffelBaseLink()
 
-    def __init__(self, version=None):
-        """Initialize with a base data object."""
+    def __init__(self, version=None, family="_", tag="_", domain_id="_"):
+        """Initialize with a base data object.
+
+        :param version: If not None use this version when loading json schemas.
+        :type version: str
+        :param family: Routing key family as per the sepia recommendation. Defaults to "_".
+        :type family: str
+        :param tag: Routing key tag as per the sepia recommendation. Defaults to "_".
+        :type tag: str
+        :param domain_id: Routing key domain id as per the sepia recommendation. Defaults to "_".
+        :type domain_id: str
+        """
         if version is not None:
             self.version = version
+        self.family = family
+        self.tag = tag
+        self.domain_id = domain_id
         self.data = EiffelBaseData()
         self.load_schema(self.version)
 
@@ -196,6 +213,16 @@ class EiffelBaseEvent(object):
         self.links.rebuild(json_data.get("links", []))
         self.load_schema(self.meta.version)
         self.validate()
+
+    @property
+    def routing_key(self):
+        """The official sepia routing key for this event."""
+        return self.__routing_key.format(
+            family=self.family,
+            type=self.meta.type,
+            tag=self.tag,
+            domain_id=self.domain_id
+        )
 
     @property
     def json(self):

--- a/eiffellib/events/eiffel_base_event.py
+++ b/eiffellib/events/eiffel_base_event.py
@@ -170,9 +170,9 @@ class EiffelBaseEvent(object):
     schema_file = None
     __schema = None
     __routing_key = "eiffel.{family}.{type}.{tag}.{domain_id}"
-    family = None
-    tag = None
-    domain_id = None
+    family = "_"
+    tag = "_"
+    domain_id = "_"
     version = "0.0.1"
     meta = EiffelBaseMeta("EiffelBaseEvent", version)
     links = EiffelBaseLink()

--- a/eiffellib/events/eiffel_composition_defined_event.py
+++ b/eiffellib/events/eiffel_composition_defined_event.py
@@ -34,9 +34,9 @@ class EiffelCompositionDefinedEvent(EiffelBaseEvent):
 
     version = "3.1.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelCompositionDefinedEvent, self).__init__(version)
+        super(EiffelCompositionDefinedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelCompositionDefinedEvent", self.version)
         self.links = EiffelCompositionDefinedLink()
         self.data = EiffelCompositionDefinedData()

--- a/eiffellib/events/eiffel_confidence_level_modified_event.py
+++ b/eiffellib/events/eiffel_confidence_level_modified_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelConfidenceLevelModifiedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelConfidenceLevelModifiedEvent, self).__init__(version)
+        super(EiffelConfidenceLevelModifiedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelConfidenceLevelModifiedEvent", self.version)
         self.links = EiffelConfidenceLevelModifiedLink()
         self.data = EiffelConfidenceLevelModifiedData()

--- a/eiffellib/events/eiffel_environment_defined_event.py
+++ b/eiffellib/events/eiffel_environment_defined_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelEnvironmentDefinedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelEnvironmentDefinedEvent, self).__init__(version)
+        super(EiffelEnvironmentDefinedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelEnvironmentDefinedEvent", self.version)
         self.links = EiffelEnvironmentDefinedLink()
         self.data = EiffelEnvironmentDefinedData()

--- a/eiffellib/events/eiffel_flow_context_defined_event.py
+++ b/eiffellib/events/eiffel_flow_context_defined_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelFlowContextDefinedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelFlowContextDefinedEvent, self).__init__(version)
+        super(EiffelFlowContextDefinedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelFlowContextDefinedEvent", self.version)
         self.links = EiffelFlowContextDefinedLink()
         self.data = EiffelFlowContextDefinedData()

--- a/eiffellib/events/eiffel_issue_defined_event.py
+++ b/eiffellib/events/eiffel_issue_defined_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelIssueDefinedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelIssueDefinedEvent, self).__init__(version)
+        super(EiffelIssueDefinedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelIssueDefinedEvent", self.version)
         self.links = EiffelIssueDefinedLink()
         self.data = EiffelIssueDefinedData()

--- a/eiffellib/events/eiffel_issue_verified_event.py
+++ b/eiffellib/events/eiffel_issue_verified_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelIssueVerifiedEvent(EiffelBaseEvent):
 
     version = "4.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelIssueVerifiedEvent, self).__init__(version)
+        super(EiffelIssueVerifiedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelIssueVerifiedEvent", self.version)
         self.links = EiffelIssueVerifiedLink()
         self.data = EiffelIssueVerifiedData()

--- a/eiffellib/events/eiffel_source_change_created_event.py
+++ b/eiffellib/events/eiffel_source_change_created_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelSourceChangeCreatedEvent(EiffelBaseEvent):
 
     version = "4.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelSourceChangeCreatedEvent, self).__init__(version)
+        super(EiffelSourceChangeCreatedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelSourceChangeCreatedEvent", self.version)
         self.links = EiffelSourceChangeCreatedLink()
         self.data = EiffelSourceChangeCreatedData()

--- a/eiffellib/events/eiffel_source_change_submitted_event.py
+++ b/eiffellib/events/eiffel_source_change_submitted_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelSourceChangeSubmittedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelSourceChangeSubmittedEvent, self).__init__(version)
+        super(EiffelSourceChangeSubmittedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelSourceChangeSubmittedEvent", self.version)
         self.links = EiffelSourceChangeSubmittedLink()
         self.data = EiffelSourceChangeSubmittedData()

--- a/eiffellib/events/eiffel_test_case_canceled_event.py
+++ b/eiffellib/events/eiffel_test_case_canceled_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelTestCaseCanceledEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelTestCaseCanceledEvent, self).__init__(version)
+        super(EiffelTestCaseCanceledEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelTestCaseCanceledEvent", self.version)
         self.links = EiffelTestCaseCanceledLink()
         self.data = EiffelTestCaseCanceledData()

--- a/eiffellib/events/eiffel_test_case_finished_event.py
+++ b/eiffellib/events/eiffel_test_case_finished_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelTestCaseFinishedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelTestCaseFinishedEvent, self).__init__(version)
+        super(EiffelTestCaseFinishedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelTestCaseFinishedEvent", self.version)
         self.links = EiffelTestCaseFinishedLink()
         self.data = EiffelTestCaseFinishedData()

--- a/eiffellib/events/eiffel_test_case_started_event.py
+++ b/eiffellib/events/eiffel_test_case_started_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelTestCaseStartedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelTestCaseStartedEvent, self).__init__(version)
+        super(EiffelTestCaseStartedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelTestCaseStartedEvent", self.version)
         self.links = EiffelTestCaseStartedLink()
         self.data = EiffelTestCaseStartedData()

--- a/eiffellib/events/eiffel_test_case_triggered_event.py
+++ b/eiffellib/events/eiffel_test_case_triggered_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelTestCaseTriggeredEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelTestCaseTriggeredEvent, self).__init__(version)
+        super(EiffelTestCaseTriggeredEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelTestCaseTriggeredEvent", self.version)
         self.links = EiffelTestCaseTriggeredLink()
         self.data = EiffelTestCaseTriggeredData()

--- a/eiffellib/events/eiffel_test_execution_recipe_collection_created_event.py
+++ b/eiffellib/events/eiffel_test_execution_recipe_collection_created_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelTestExecutionRecipeCollectionCreatedEvent(EiffelBaseEvent):
 
     version = "4.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelTestExecutionRecipeCollectionCreatedEvent, self).__init__(version)
+        super(EiffelTestExecutionRecipeCollectionCreatedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelTestExecutionRecipeCollectionCreatedEvent", self.version)
         self.links = EiffelTestExecutionRecipeCollectionCreatedLink()
         self.data = EiffelTestExecutionRecipeCollectionCreatedData()

--- a/eiffellib/events/eiffel_test_suite_finished_event.py
+++ b/eiffellib/events/eiffel_test_suite_finished_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,9 +34,9 @@ class EiffelTestSuiteFinishedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelTestSuiteFinishedEvent, self).__init__(version)
+        super(EiffelTestSuiteFinishedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelTestSuiteFinishedEvent", self.version)
         self.links = EiffelTestSuiteFinishedLink()
         self.data = EiffelTestSuiteFinishedData()

--- a/eiffellib/events/eiffel_test_suite_started_event.py
+++ b/eiffellib/events/eiffel_test_suite_started_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Axis Communications AB.
+# Copyright 2019-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -34,8 +34,8 @@ class EiffelTestSuiteStartedEvent(EiffelBaseEvent):
 
     version = "3.0.0"
 
-    def __init__(self, version=None):
+    def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
-        super(EiffelTestSuiteStartedEvent, self).__init__(version)
+        super(EiffelTestSuiteStartedEvent, self).__init__(*args, **kwargs)
         self.meta = EiffelBaseMeta("EiffelTestSuiteStartedEvent", self.version)
         self.links = EiffelTestSuiteStartedLink()


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: #36 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add a routing_key property for events.
Deprecate the routing_key argument for RabbitMQPublisher

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We could also add the routing key arguments to the "send_event" method in the RabbitMQPublisher instead, however I felt like this was something that the events should handle.

### Benefits
<!-- What benefits will be realized by the change? -->
We would follow sepia and allow for more fine grained control of what to receive in Subscribers.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
This is, potentially, a breaking change for some people

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
