### PR TITLE
Add a method for waiting for unpublished events

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ Publishing an event
     ACTIVITY_TRIGGERED = EiffelActivityTriggeredEvent()
     ACTIVITY_TRIGGERED.data.add("name", "Test activity")
     PUBLISHER.send_event(ACTIVITY_TRIGGERED)
+    PUBLISHER.wait_for_unpublished_events()
 
 Deprecation of routing key
 --------------------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -24,7 +24,6 @@ This code snippet will subscribe to an ActivityStarted in order to publish an Ac
 
 .. code-block:: python
 
-    import time
     from eiffellib.subscribers import RabbitMQSubscriber
     from eiffellib.publishers import RabbitMQPublisher
     from eiffellib.events import (EiffelActivityTriggeredEvent,
@@ -68,7 +67,7 @@ This code snippet will subscribe to an ActivityStarted in order to publish an Ac
     PUBLISHER.send_event(ACTIVITY_STARTED)
 
     # Wait for event to be received by 'callback'.
-    time.sleep(1)
+    PUBLISHER.wait_for_unpublished_events()
 
 Activity
 --------
@@ -80,7 +79,6 @@ An activity is just a callable which will send ActivityTriggered, Started and Fi
 .. code-block:: python
 
     import os
-    import time
     from eiffellib.subscribers import RabbitMQSubscriber
     from eiffellib.publishers import RabbitMQPublisher
     from eiffellib.events import EiffelAnnouncementPublishedEvent
@@ -117,4 +115,4 @@ An activity is just a callable which will send ActivityTriggered, Started and Fi
     PUBLISHER.send_event(ANNOUNCEMENT)
 
     # Wait for event to be received by 'callback'.
-    time.sleep(1)
+    PUBLISHER.wait_for_unpublished_events()

--- a/eiffellib/publishers/eiffel_publisher.py
+++ b/eiffellib/publishers/eiffel_publisher.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2022 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -43,6 +43,15 @@ class EiffelPublisher():
 
         :param msg: Message to send.
         :type msg: str
+        """
+        raise NotImplementedError
+
+    def wait_for_unpublished_events(timeout=60):
+        """Wait for all unpublished events to become published.
+
+        :raises TimeoutError: If the timeout is reached, this will be raised.
+        :param timeout: A timeout, in seconds, to wait before exiting.
+        :type timeout: int
         """
         raise NotImplementedError
 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: #41 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
This was triggered due to a documentation error in the README plus the fact that we are seeing this issue ourselves.
Basically there was no way to check that events have been published to the broker before exiting the publisher.
This change adds a method for waiting for unpublished events.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We could open up the `_deliveries` and `_nacked_deliveries` so the users can create their own wait methods, but I feel that this should be a feature in the library.
We could also add this as a step when shutting down the publisher, but I decided against it due to it being a bigger change for users.

### Benefits
<!-- What benefits will be realized by the change? -->
This will allow users to wait for broker ACK before exiting when publishing events

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None that I can see

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
