### PR TITLE
Fix a problem where the RabbitMQPublisher could deadlock

### DIFF
--- a/eiffellib/publishers/rabbitmq_publisher.py
+++ b/eiffellib/publishers/rabbitmq_publisher.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Axis Communications AB.
+# Copyright 2020-2022 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
There have been multiple problems with this code. One problem is that it would send events from two different threads. The main thread and the thread that resends nacked events. This could cause the RabbitMQ server to disconnect the client.
Secondly since the send_event method would block and wait for the client to reconnect in case of disconnects, the resend_nacked_events method could block the IOLoop which would prevent the client from reconnecting, thus causing a deadlock

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I thought about having a queue of events instead which send_event and _resend_nacked_events would populate and having a separate thread go through this queue and send events.
This was a part of the previous design of this library and it had multiple problems due to the complexity that threading adds when using pika.

### Benefits
<!-- What benefits will be realized by the change? -->
Deadlocks are dangerous and we don't want to have to reconnect because we behave badly.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
This adds more complexity and overhead.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
