### PR TITLE
MAINT: remove hard coded event type class name.

### DIFF
--- a/eiffellib/events/eiffel_activity_canceled_event.py
+++ b/eiffellib/events/eiffel_activity_canceled_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_activity_canceled_event.py
+++ b/eiffellib/events/eiffel_activity_canceled_event.py
@@ -37,6 +37,6 @@ class EiffelActivityCanceledEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelActivityCanceledEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelActivityCanceledEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelActivityCanceledLink()
         self.data = EiffelActivityCanceledData()

--- a/eiffellib/events/eiffel_activity_finished_event.py
+++ b/eiffellib/events/eiffel_activity_finished_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_activity_finished_event.py
+++ b/eiffellib/events/eiffel_activity_finished_event.py
@@ -37,6 +37,6 @@ class EiffelActivityFinishedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelActivityFinishedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelActivityFinishedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelActivityFinishedLink()
         self.data = EiffelActivityFinishedData()

--- a/eiffellib/events/eiffel_activity_started_event.py
+++ b/eiffellib/events/eiffel_activity_started_event.py
@@ -37,6 +37,6 @@ class EiffelActivityStartedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelActivityStartedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelActivityStartedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelActivityStartedLink()
         self.data = EiffelActivityStartedData()

--- a/eiffellib/events/eiffel_activity_started_event.py
+++ b/eiffellib/events/eiffel_activity_started_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_activity_triggered_event.py
+++ b/eiffellib/events/eiffel_activity_triggered_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_activity_triggered_event.py
+++ b/eiffellib/events/eiffel_activity_triggered_event.py
@@ -37,6 +37,6 @@ class EiffelActivityTriggeredEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelActivityTriggeredEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelActivityTriggeredEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelActivityTriggeredLink()
         self.data = EiffelActivityTriggeredData()

--- a/eiffellib/events/eiffel_announcement_published_event.py
+++ b/eiffellib/events/eiffel_announcement_published_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_announcement_published_event.py
+++ b/eiffellib/events/eiffel_announcement_published_event.py
@@ -37,6 +37,6 @@ class EiffelAnnouncementPublishedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelAnnouncementPublishedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelAnnouncementPublishedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelAnnouncementPublishedLink()
         self.data = EiffelAnnouncementPublishedData()

--- a/eiffellib/events/eiffel_artifact_created_event.py
+++ b/eiffellib/events/eiffel_artifact_created_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_artifact_created_event.py
+++ b/eiffellib/events/eiffel_artifact_created_event.py
@@ -37,6 +37,6 @@ class EiffelArtifactCreatedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelArtifactCreatedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelArtifactCreatedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelArtifactCreatedLink()
         self.data = EiffelArtifactCreatedData()

--- a/eiffellib/events/eiffel_artifact_published_event.py
+++ b/eiffellib/events/eiffel_artifact_published_event.py
@@ -37,6 +37,6 @@ class EiffelArtifactPublishedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelArtifactPublishedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelArtifactPublishedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelArtifactPublishedLink()
         self.data = EiffelArtifactPublishedData()

--- a/eiffellib/events/eiffel_artifact_published_event.py
+++ b/eiffellib/events/eiffel_artifact_published_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_artifact_reused_event.py
+++ b/eiffellib/events/eiffel_artifact_reused_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_artifact_reused_event.py
+++ b/eiffellib/events/eiffel_artifact_reused_event.py
@@ -37,6 +37,6 @@ class EiffelArtifactReusedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelArtifactReusedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelArtifactReusedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelArtifactReusedLink()
         self.data = EiffelArtifactReusedData()

--- a/eiffellib/events/eiffel_base_event.py
+++ b/eiffellib/events/eiffel_base_event.py
@@ -174,7 +174,7 @@ class EiffelBaseEvent(object):
     tag = "_"
     domain_id = "_"
     version = "0.0.1"
-    meta = EiffelBaseMeta("EiffelBaseEvent", version)
+    meta = EiffelBaseMeta(__qualname__, version)
     links = EiffelBaseLink()
 
     def __init__(self, version=None, family="_", tag="_", domain_id="_"):

--- a/eiffellib/events/eiffel_base_event.py
+++ b/eiffellib/events/eiffel_base_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_composition_defined_event.py
+++ b/eiffellib/events/eiffel_composition_defined_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_composition_defined_event.py
+++ b/eiffellib/events/eiffel_composition_defined_event.py
@@ -37,6 +37,6 @@ class EiffelCompositionDefinedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelCompositionDefinedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelCompositionDefinedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelCompositionDefinedLink()
         self.data = EiffelCompositionDefinedData()

--- a/eiffellib/events/eiffel_confidence_level_modified_event.py
+++ b/eiffellib/events/eiffel_confidence_level_modified_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_confidence_level_modified_event.py
+++ b/eiffellib/events/eiffel_confidence_level_modified_event.py
@@ -37,6 +37,6 @@ class EiffelConfidenceLevelModifiedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelConfidenceLevelModifiedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelConfidenceLevelModifiedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelConfidenceLevelModifiedLink()
         self.data = EiffelConfidenceLevelModifiedData()

--- a/eiffellib/events/eiffel_environment_defined_event.py
+++ b/eiffellib/events/eiffel_environment_defined_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_environment_defined_event.py
+++ b/eiffellib/events/eiffel_environment_defined_event.py
@@ -37,6 +37,6 @@ class EiffelEnvironmentDefinedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelEnvironmentDefinedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelEnvironmentDefinedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelEnvironmentDefinedLink()
         self.data = EiffelEnvironmentDefinedData()

--- a/eiffellib/events/eiffel_flow_context_defined_event.py
+++ b/eiffellib/events/eiffel_flow_context_defined_event.py
@@ -37,6 +37,6 @@ class EiffelFlowContextDefinedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelFlowContextDefinedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelFlowContextDefinedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelFlowContextDefinedLink()
         self.data = EiffelFlowContextDefinedData()

--- a/eiffellib/events/eiffel_flow_context_defined_event.py
+++ b/eiffellib/events/eiffel_flow_context_defined_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_issue_defined_event.py
+++ b/eiffellib/events/eiffel_issue_defined_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_issue_defined_event.py
+++ b/eiffellib/events/eiffel_issue_defined_event.py
@@ -37,6 +37,6 @@ class EiffelIssueDefinedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelIssueDefinedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelIssueDefinedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelIssueDefinedLink()
         self.data = EiffelIssueDefinedData()

--- a/eiffellib/events/eiffel_issue_verified_event.py
+++ b/eiffellib/events/eiffel_issue_verified_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_issue_verified_event.py
+++ b/eiffellib/events/eiffel_issue_verified_event.py
@@ -37,6 +37,6 @@ class EiffelIssueVerifiedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelIssueVerifiedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelIssueVerifiedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelIssueVerifiedLink()
         self.data = EiffelIssueVerifiedData()

--- a/eiffellib/events/eiffel_source_change_created_event.py
+++ b/eiffellib/events/eiffel_source_change_created_event.py
@@ -37,6 +37,6 @@ class EiffelSourceChangeCreatedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelSourceChangeCreatedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelSourceChangeCreatedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelSourceChangeCreatedLink()
         self.data = EiffelSourceChangeCreatedData()

--- a/eiffellib/events/eiffel_source_change_created_event.py
+++ b/eiffellib/events/eiffel_source_change_created_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_source_change_submitted_event.py
+++ b/eiffellib/events/eiffel_source_change_submitted_event.py
@@ -37,6 +37,6 @@ class EiffelSourceChangeSubmittedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelSourceChangeSubmittedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelSourceChangeSubmittedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelSourceChangeSubmittedLink()
         self.data = EiffelSourceChangeSubmittedData()

--- a/eiffellib/events/eiffel_source_change_submitted_event.py
+++ b/eiffellib/events/eiffel_source_change_submitted_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_test_case_canceled_event.py
+++ b/eiffellib/events/eiffel_test_case_canceled_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_test_case_canceled_event.py
+++ b/eiffellib/events/eiffel_test_case_canceled_event.py
@@ -37,6 +37,6 @@ class EiffelTestCaseCanceledEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelTestCaseCanceledEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelTestCaseCanceledEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelTestCaseCanceledLink()
         self.data = EiffelTestCaseCanceledData()

--- a/eiffellib/events/eiffel_test_case_finished_event.py
+++ b/eiffellib/events/eiffel_test_case_finished_event.py
@@ -37,6 +37,6 @@ class EiffelTestCaseFinishedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelTestCaseFinishedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelTestCaseFinishedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelTestCaseFinishedLink()
         self.data = EiffelTestCaseFinishedData()

--- a/eiffellib/events/eiffel_test_case_finished_event.py
+++ b/eiffellib/events/eiffel_test_case_finished_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_test_case_started_event.py
+++ b/eiffellib/events/eiffel_test_case_started_event.py
@@ -37,6 +37,6 @@ class EiffelTestCaseStartedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelTestCaseStartedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelTestCaseStartedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelTestCaseStartedLink()
         self.data = EiffelTestCaseStartedData()

--- a/eiffellib/events/eiffel_test_case_started_event.py
+++ b/eiffellib/events/eiffel_test_case_started_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_test_case_triggered_event.py
+++ b/eiffellib/events/eiffel_test_case_triggered_event.py
@@ -37,6 +37,6 @@ class EiffelTestCaseTriggeredEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelTestCaseTriggeredEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelTestCaseTriggeredEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelTestCaseTriggeredLink()
         self.data = EiffelTestCaseTriggeredData()

--- a/eiffellib/events/eiffel_test_case_triggered_event.py
+++ b/eiffellib/events/eiffel_test_case_triggered_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_test_execution_recipe_collection_created_event.py
+++ b/eiffellib/events/eiffel_test_execution_recipe_collection_created_event.py
@@ -37,6 +37,6 @@ class EiffelTestExecutionRecipeCollectionCreatedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelTestExecutionRecipeCollectionCreatedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelTestExecutionRecipeCollectionCreatedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelTestExecutionRecipeCollectionCreatedLink()
         self.data = EiffelTestExecutionRecipeCollectionCreatedData()

--- a/eiffellib/events/eiffel_test_execution_recipe_collection_created_event.py
+++ b/eiffellib/events/eiffel_test_execution_recipe_collection_created_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_test_suite_finished_event.py
+++ b/eiffellib/events/eiffel_test_suite_finished_event.py
@@ -37,6 +37,6 @@ class EiffelTestSuiteFinishedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelTestSuiteFinishedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelTestSuiteFinishedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelTestSuiteFinishedLink()
         self.data = EiffelTestSuiteFinishedData()

--- a/eiffellib/events/eiffel_test_suite_finished_event.py
+++ b/eiffellib/events/eiffel_test_suite_finished_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/eiffellib/events/eiffel_test_suite_started_event.py
+++ b/eiffellib/events/eiffel_test_suite_started_event.py
@@ -37,5 +37,5 @@ class EiffelTestSuiteStartedEvent(EiffelBaseEvent):
     def __init__(self, *args, **kwargs):
         """Initialize data, meta and links."""
         super(EiffelTestSuiteStartedEvent, self).__init__(*args, **kwargs)
-        self.meta = EiffelBaseMeta("EiffelTestSuiteStartedEvent", self.version)
+        self.meta = EiffelBaseMeta(self.__class__.__name__, self.version)
         self.links = EiffelTestSuiteStartedLink()

--- a/eiffellib/events/eiffel_test_suite_started_event.py
+++ b/eiffellib/events/eiffel_test_suite_started_event.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Axis Communications AB.
+# Copyright 2019-2022 Axis Communications AB and others.
 #
 # For a full list of individual contributors, please see the commit history.
 #


### PR DESCRIPTION
### Applicable Issues
fixes: https://github.com/eiffel-community/eiffel-pythonlib/issues/45

### Description of the Change
Replace using hard coded event type class name with the builtin attribute `__class__.__name__`  or `__qualname__`.

### Alternate Designs
N/A

### Benefits
Easier maintenance in case changing

### Possible Drawbacks
N/A

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Eman Ismail  <emanismail.92@gmail.com> 
