### PR TITLE
Set default RabbitMQ port to 5672 not 5671

### DIFF
--- a/eiffellib/publishers/rabbitmq_publisher.py
+++ b/eiffellib/publishers/rabbitmq_publisher.py
@@ -41,7 +41,7 @@ class RabbitMQPublisher(EiffelPublisher, BaseRabbitMQ):
 
     # pylint:disable=too-many-arguments
     def __init__(self, host, exchange, routing_key="eiffel",
-                 username=None, password=None, port=5671, vhost=None,
+                 username=None, password=None, port=5672, vhost=None,
                  source=None, ssl=True):
         """Initialize with host and create pika connection parameters."""
         BaseRabbitMQ.__init__(self, host, port, username, password, vhost, ssl)

--- a/eiffellib/subscribers/rabbitmq_subscriber.py
+++ b/eiffellib/subscribers/rabbitmq_subscriber.py
@@ -39,7 +39,7 @@ class RabbitMQSubscriber(EiffelSubscriber, BaseRabbitMQ):
     __workers = None
 
     # pylint:disable=too-many-arguments
-    def __init__(self, host, queue, exchange, username=None, password=None, port=5671,
+    def __init__(self, host, queue, exchange, username=None, password=None, port=5672,
                  vhost=None, routing_key=None, ssl=True, queue_params=None):
         """Initialize with rabbitmq host."""
         super(RabbitMQSubscriber, self).__init__()


### PR DESCRIPTION
The default AMQP port is 5672 not 5671
